### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow to help you get started with Actions
 
 name: CI
+permissions:
+  contents: read
 
 # Controls when the workflow will run
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Kash1444/Engineering-Notes-Hub/security/code-scanning/1](https://github.com/Kash1444/Engineering-Notes-Hub/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow only checks out the repository and runs simple scripts, it likely only requires `contents: read` permission. This will explicitly limit the permissions of the `GITHUB_TOKEN` to the minimum necessary for the workflow to function correctly.

The `permissions` block will be added at the root level of the workflow, applying to all jobs in the workflow. This ensures that all jobs inherit the same minimal permissions unless explicitly overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
